### PR TITLE
Fix rake test error

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,5 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
-
   # Add more helper methods to be used by all tests here...
 end


### PR DESCRIPTION
@jarodreyes, I looked into the issue #10.

<img width="960" alt="1__zsh" src="https://cloud.githubusercontent.com/assets/957202/10126650/0a013ae4-655c-11e5-9c14-6a314e1ccd54.png">

This issue was caused because the fixture infrastructure was not loaded since this application is not using ActiveRecord. Furthermore the test suite is not using fixtures, so I think the most convenient solution is just to remove `fixtures :all`, what do you think? After apply the fix you'll be able to run `rake test` smoothly.

<img width="604" alt="1__zsh" src="https://cloud.githubusercontent.com/assets/957202/10126628/9cf46494-655b-11e5-89e4-0acdbf8e864b.png">

**Note:** The failure on the test suite has a different cause, I'll open an issue for that one.